### PR TITLE
fix: allow region flag to overwrite AWS env region

### DIFF
--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -65,14 +65,14 @@ var cleanCmd = &cobra.Command{
 		awsEnvProfile = os.Getenv("AWS_PROFILE")
 		userAgent = fmt.Sprintf("go-lambda-cleanup-%s", VersionString)
 
-		if awsEnvRegion == "" {
-			if RegionFlag != "" {
-				region = validateRegion(f, RegionFlag)
+		if RegionFlag == "" {
+			if awsEnvRegion != "" {
+				region = validateRegion(f, awsEnvRegion)
 			} else {
-				log.Fatal("ERROR: Missing region flag. Please use -r and provide a valid AWS region.")
+				log.Fatal("ERROR: Missing region flag and AWS_DEFAULT_REGION env variable. Please use -r and provide a valid AWS region.")
 			}
 		} else {
-			region = validateRegion(f, awsEnvRegion)
+			region = validateRegion(f, RegionFlag)
 		}
 
 		ctx = context.Background()


### PR DESCRIPTION
Most of the time there as an AWS_DEFAULT_REGION env variable which may
be not the region where the clean command should run.

Switching the region flag with the region env variable allows users to
overwrite the AWS_DEFAULT_REGION with a specific region.

Running without --region flag:
![image](https://user-images.githubusercontent.com/439128/156746542-0e33b2c9-2a8a-4ec6-95ba-a4dd019a1415.png)

Running with --region flag:
![image](https://user-images.githubusercontent.com/439128/156746575-436d0856-5132-483f-b6d6-bdd461ce004a.png)
