### PR TITLE
Go lint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,12 +49,11 @@ jobs:
       run: |
         aws ec2 describe-regions --region us-east-1 --query "Regions[].RegionName" --output text >> cmd/aws-regions.txt
 
-    - name: golangci-lint
-      uses: golangci/golangci-lint-action@v2
-      with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.29
-          args: -v
+    - name: Run golangci-lint
+      uses: golangci/golangci-lint-action@v3.1.0
+      with:  
+        args: -v
+
     
     - name: Execute Go tests
       run: go test -v ./...

--- a/README.md
+++ b/README.md
@@ -187,7 +187,9 @@ A: You have two options.
 
 Option A is to clone this project and compile the binary. Issue `go build -o glc`, and the end result is a binary compatible for your system. If you still encounter issues after this, invoke the code signing command on the binary `codesign -s -`
 
-Option B is not recommended but I'll offer it up. You can remove the binary from quarantine mode. 
+Option B is to to grant permission for the application to run. Use [this guide](https://support.apple.com/en-us/HT202491) to help you grant permission to the application.
+
+Option C is not recommended but I'll offer it up. You can remove the binary from quarantine mode. 
 ```shell
 xattr -d com.apple.quarantine /path/to/file
 ```


### PR DESCRIPTION
This PR updates the golangci-lint version. The previous version was breaking due to Go 1.18.