### PR TITLE
add assume role credential option to support MFA tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ go-lambda-clean utilizes the default AWS Go SDK credentials provider to find AWS
 
 4. If your application is running on an Amazon EC2 instance, IAM role for Amazon EC2.
 
+_If there is an MFA serial attached to the credentials, you will be prompted for an MFA token._
+
 #### Shared File Example
 If `~/.aws/config` and `~/.aws/config` is setup for the AWS CLI then you may leverage the existing profile configuration for authentication.
 ```shell

--- a/cmd/clean.go
+++ b/cmd/clean.go
@@ -15,6 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/middleware"
 	awsConfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
 	"github.com/aws/aws-sdk-go-v2/service/lambda/types"
 	"github.com/dustin/go-humanize"
@@ -71,6 +72,9 @@ var cleanCmd = &cobra.Command{
 		awsConfigOptions := []func(*awsConfig.LoadOptions) error{
 			awsConfig.WithRegion(*config.RegionFlag),
 			awsConfig.WithHTTPClient(GlobalHTTPClient),
+			awsConfig.WithAssumeRoleCredentialOptions(func(aro *stscreds.AssumeRoleOptions) {
+				aro.TokenProvider = stscreds.StdinTokenProvider
+			}),
 		}
 		if *config.ProfileFlag == "" {
 			if awsEnvProfile != "" {


### PR DESCRIPTION
Closes #73 

When executed with an MFA serial:

```
$ glc clean -i -r us-east-1 -p profile_name -c 10
INFO[03/23/23] The AWS Profile flag "profile_name" was passed in
Assume Role MFA token code: 123456
INFO[03/23/23] Scanning AWS environment in us-east-1
INFO[03/23/23] ............
INFO[03/23/23] 10 Lambdas identified
INFO[03/23/23] Current storage size: 2.0 GiB
```