### PR TITLE
docs: fixed issue with version prefix and Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ sudo mv glc /usr/local/bin/
 go-lambda-cleanup is also available as a Docker image. Check out the [GitHub Packages](https://github.com/karl-cardenas-coding/go-lambda-cleanup/pkgs/container/go-lambda-cleanup) page for this repository to learn more about the available images.
 
 ```
-VERSION=2.0.15
+VERSION=v2.0.15
 docker pull ghcr.io/karl-cardenas-coding/go-lambda-cleanup:$VERSION
 ```
 
@@ -289,7 +289,7 @@ on:
     # At 04:00 on every day
     - cron: '0 04 * * *'
 env:
-  VERSION: 2.0.15
+  VERSION: 'v2.0.15'
 
 jobs:
   build:


### PR DESCRIPTION
This PR fixes an issue with the documentation examples that caused issues for those attempting to download the images.

